### PR TITLE
Rollenbezeichnung: Web → Frontend Developer

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -102,7 +102,7 @@ export function Hero() {
         className="mt-6 font-black uppercase leading-[0.8] tracking-[-0.04em] text-[clamp(2.8rem,13vw,10rem)] md:mt-8"
       >
         <span className="intro-left block">
-          Web
+          Frontend
           <br />
           Developer
         </span>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -29,7 +29,7 @@ export const interfaceStatementShort = "Interfaces, die sich gut anfühlen.";
 export const backendStatement =
   "Für mich hört Frontend nicht beim Design auf. Aus meiner Zeit im Backend weiß ich, was hinter einer Schnittstelle passiert.";
 
-export const aboutStatement = `Web-Entwickler mit Fokus auf React, Next.js und TypeScript. Meine Basis habe ich bei der Schwarz Gruppe im Team hinter kaufland.de gelegt: Komponenten nach festen Designrichtlinien gebaut, in einem großen System, das wartbar bleiben muss. Später habe ich noch im Bereich Backend und UX/UI gearbeitet. Ich weiß, was auf der anderen Seite einer Schnittstelle passiert, und arbeite mit Designern auf Augenhöhe.
+export const aboutStatement = `Frontend-Entwickler mit Fokus auf React, Next.js und TypeScript. Meine Basis habe ich bei der Schwarz Gruppe im Team hinter kaufland.de gelegt: Komponenten nach festen Designrichtlinien gebaut, in einem großen System, das wartbar bleiben muss. Später habe ich noch im Bereich Backend und UX/UI gearbeitet. Ich weiß, was auf der anderen Seite einer Schnittstelle passiert, und arbeite mit Designern auf Augenhöhe.
 
 Nach einer zusätzlichen Weiterbildung im Web Development habe ich drei Projekte gebaut, die reale Probleme lösen: eine Finanz-App mit serverseitiger Budget-Logik, einen Doku-Assistenten mit RAG-Pipeline und hybrider Suche, und eine DIY-Plattform für Hobbywerker. Mich interessiert Frontend da, wo es auf Nutzer trifft — Interfaces, die im Gebrauch funktionieren, nicht nur im Design.`;
 


### PR DESCRIPTION
## Was

Die Rollenbezeichnung wurde von "Web Developer" / "Web-Entwickler" auf "Frontend Developer" / "Frontend-Entwickler" umgestellt.

- **Hero-Überschrift** (`src/components/Hero.tsx`): große H1 zeigt jetzt "Frontend / Developer" statt "Web / Developer".
- **Über-mich-Text** (`src/lib/data.ts`): Statement beginnt mit "Frontend-Entwickler mit Fokus auf React…".

## Warum

Vereinheitlicht die Kopie mit dem Rest der Seite (Nav, Meta-Tags, Rollenzeile sagten bereits "Frontend Developer").

## Hinweis für Reviewer

Bewusst nur die beiden Text-Änderungen enthalten. Vorhandene, nicht committete Hydration-/Reveal-Arbeit (globals.css, layout.tsx, HydrationFlag.tsx) ist absichtlich **nicht** Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)